### PR TITLE
Update deephaven-plugin to latest, fixed API breaking changes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    deephaven-plugin
+    deephaven-plugin>=0.5.0
     plotly
 include_package_data = True
 

--- a/src/deephaven/plot/express/__init__.py
+++ b/src/deephaven/plot/express/__init__.py
@@ -1,5 +1,5 @@
-from deephaven.plugin import Registration
-from deephaven.plugin.object import Exporter, ObjectType
+from deephaven.plugin import Registration, Callback
+from deephaven.plugin.object_type import Exporter, FetchOnlyObjectType
 
 from .deephaven_figure import DeephavenFigure, export_figure
 
@@ -39,7 +39,7 @@ __version__ = "0.0.5"
 NAME = "deephaven.plot.express.DeephavenFigure"
 
 
-class DeephavenFigureType(ObjectType):
+class DeephavenFigureType(FetchOnlyObjectType):
     """
     DeephavenFigureType for plugin registration
 
@@ -56,17 +56,17 @@ class DeephavenFigureType(ObjectType):
         """
         return NAME
 
-    def is_type(self, object: any) -> bool:
+    def is_type(self, obj: any) -> bool:
         """
         Check if an object is a DeephavenFigure
 
         Args:
-          object: any: The object to check
+          obj: any: The object to check
 
         Returns:
             bool: True if the object is of the correct type, False otherwise
         """
-        return isinstance(object, DeephavenFigure)
+        return isinstance(obj, DeephavenFigure)
 
     def to_bytes(self, exporter: Exporter, figure: DeephavenFigure) -> bytes:
         """
@@ -89,7 +89,7 @@ class ChartRegistration(Registration):
     """
 
     @classmethod
-    def register_into(cls, callback: Registration.Callback) -> None:
+    def register_into(cls, callback: Callback) -> None:
         """
         Register the DeephavenFigureType
 

--- a/src/deephaven/plot/express/data_mapping/DataMapping.py
+++ b/src/deephaven/plot/express/data_mapping/DataMapping.py
@@ -4,7 +4,7 @@ from copy import copy
 from typing import Any
 
 from deephaven.table import Table
-from deephaven.plugin.object import Exporter
+from deephaven.plugin.object_type import Exporter
 
 from .json_conversion import json_link_mapping
 
@@ -45,7 +45,7 @@ class DataMapping:
         """
         return json_link_mapping(
             self._data_mapping,
-            exporter.reference(self._table)._index,
+            exporter.reference(self._table).index,
             self._start_index)
 
     def copy(

--- a/src/deephaven/plot/express/deephaven_figure/DeephavenFigure.py
+++ b/src/deephaven/plot/express/deephaven_figure/DeephavenFigure.py
@@ -6,7 +6,7 @@ from typing import Callable, Any
 
 from plotly.graph_objects import Figure
 
-from deephaven.plugin.object import Exporter
+from deephaven.plugin.object_type import Exporter
 
 from ..data_mapping import DataMapping
 

--- a/test/deephaven/plot/express/BaseTest.py
+++ b/test/deephaven/plot/express/BaseTest.py
@@ -14,8 +14,8 @@ class BaseTestCase(unittest.TestCase):
         cls.setup_exporter_mock()
 
     @classmethod
-    @patch('deephaven.plugin.object.Exporter')
-    @patch('deephaven.plugin.object.Reference')
+    @patch('deephaven.plugin.object_type.Exporter')
+    @patch('deephaven.plugin.object_type.Reference')
     def setup_exporter_mock(cls, MockExporter, MockReference):
         cls.exporter = MockExporter()
         cls.reference = MockReference()


### PR DESCRIPTION
I was unable to confirm that the tests are passing, there is no command in docs or CI files that show how to run them. We used `python -m unittest discover test/deephaven` to try to run them (without the `deephaven` suffix, there is a package shadowing issue from the empty `__init__.py` files that possibly should be removed?).

```
======================================================================
ERROR: test_basic_area (plot.express.plots.test_area.AreaTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/colin/workspace/deephaven-plugin-plotly-express/test/deephaven/plot/express/plots/test_area.py", line 24, in test_basic_area
    chart = dx.area(self.source, x="X", y="Y").to_dict(self.exporter)
  File "/home/colin/workspace/deephaven-plugin-plotly-express/src/deephaven/plot/express/deephaven_figure/DeephavenFigure.py", line 168, in to_dict
    return json.loads(self.to_json(exporter))
  File "/home/colin/workspace/deephaven-plugin-plotly-express/src/deephaven/plot/express/deephaven_figure/DeephavenFigure.py", line 194, in to_json
    return json.dumps(payload)
  File "/home/colin/.pyenv/versions/3.10.11/lib/python3.10/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/home/colin/.pyenv/versions/3.10.11/lib/python3.10/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/home/colin/.pyenv/versions/3.10.11/lib/python3.10/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/home/colin/.pyenv/versions/3.10.11/lib/python3.10/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type MagicMock is not JSON serializable

----------------------------------------------------------------------
Ran 1 test in 6.449s
```

We did verify that the changes work by using the current version of the plotly-express plugin and installing this wheel. The above failure _looks_ legit, a mock maybe shouldn't be serializable, but I wasn't sure how this should go.